### PR TITLE
Add $6k private contract floor and independent railroad route cap

### DIFF
--- a/docs/Contract generation.md
+++ b/docs/Contract generation.md
@@ -66,6 +66,8 @@ Private contracts are offered to a player just after they fulfill a prior privat
 
 3. **Select commodity**: Available in cities that are within 1 segment of the player’s active cities. Excludes commodities produced in the destination city. Chosen at random with equal probability. When generating multiple private contract offers, one offer may be generated with commodity restricted to the player's regional office region (if any).
 
+4. **Minimum value floor**: If the current player has 3 or more fulfilled contracts (private or market, combined), the commodity choice in step 3 is restricted to commodities whose nearest producing city is at least 2 segments from the destination (i.e. worth at least $6,000). If this restriction would leave fewer than 2 eligible commodities, the restriction is skipped and the full candidate list from step 3 is used instead. The same floor applies to regional-office offers.
+
 ---
 
 ## Starting private contract
@@ -98,6 +100,6 @@ Starting contracts are a special kind of private contract given to players durin
 2. **Select commodity**
    - Must be available in active cities or cities within 1 segment of active cities (including the active cities).
    - Must **not** be produced in the destination city.
-   - Must have **distance ≥ 2** from the destination (shortest path to any city that produces the commodity). This ensures a minimum cash reward of $6,000 (2 segments × $3,000).
+   - Must have **distance ≥ 2** from the destination (shortest path to any city that produces the commodity). This ensures a minimum cash reward of $6,000 (2 segments × $3,000). Market and private generation share this distance filter via `filterCommoditiesByMinDistance` in [Contract.ts](../src/Contract.ts); market always requires it, while private applies it only under the minimum-value floor in step 4 above.
 
 3. Chosen at random with equal probability among valid commodities.

--- a/docs/GAME_DATA_SCHEMA.md
+++ b/docs/GAME_DATA_SCHEMA.md
@@ -1,0 +1,183 @@
+# Game Data Schema
+
+**For AI agents and humans:** This is a concise reference for the shapes of `G` (game state), `ctx` (game context), and the hard-coded map data (cities, routes, commodities). Use it when reading, writing, or extending game data. It documents *shape*, not behavior — see [AGENTS.md](../AGENTS.md) and [PHASES_AGENT_GUIDE.md](PHASES_AGENT_GUIDE.md) for where logic lives.
+
+---
+
+## 1. `G` — game state
+
+**Source of truth:** `src/stores/gameStore.ts` (`GameState`). Accessed via the `useGameStore` Zustand hook or `useGame()`. Never duplicate this elsewhere (see [AGENTS.md](../AGENTS.md)).
+
+```ts
+export type RegionCode = 'NW' | 'NC' | 'NE' | 'SW' | 'SC' | 'SE';
+
+export interface PlayerProps {
+  name: string;
+  activeCities: string[];      // city keys, ordered; last entry = player's "current" city
+  hubCity: string | null;      // city key, or null
+  regionalOffice: RegionCode | null;
+}
+
+export interface IndependentRailroadRoute {
+  key: string;                 // route key (into `routes` map)
+  addedInRound: number;        // ctx.round when this route was assigned
+}
+
+export interface GameState {
+  contracts: Contract[];
+  players: [string, PlayerProps][];   // tuple array; first element is player ID (e.g. "0", "1")
+  independentRailroads: Record<
+    string,                                             // company name
+    { name: string; routes: IndependentRailroadRoute[] }
+  >;
+  byodGameStarted?: boolean;          // BYOD only: true once host starts the game
+  lastRoundRoutesAdded?: number;      // UI hint; set when growIndependentRailroads adds routes
+}
+```
+
+| Field | Notes |
+|---|---|
+| `contracts` | All contracts (market + private), see [`Contract`](#contract-in-gcontracts) below |
+| `players` | Array of `[playerID, PlayerProps]` tuples — **not** a plain object; find with `G.players.find(([id]) => id === playerID)` |
+| `players[].activeCities` | Cities the player has expanded into; last entry drives contract generation ("current city") |
+| `players[].hubCity` / `.regionalOffice` | Optional player upgrades; `regionalOffice` gates commodity region in contract generation |
+| `independentRailroads` | Keyed by generated company name; grown over time by `growIndependentRailroads` (see `src/independentRailroads.ts`) |
+
+### `Contract` (in `G.contracts`)
+
+**Source:** `src/Contract.ts`.
+
+```ts
+export interface Contract {
+  id: string;                    // `${commodity.slice(0,3)}-${city.id}-${timestamp.toString(16)}`
+  destinationKey: string;        // city key (into `cities` map)
+  commodity: string;             // commodity key (into `commodities` map)
+  type: "market" | "private";
+  fulfilled: boolean;
+  playerID: string | null;       // null only for unclaimed market contracts
+  creationTime: number;          // Date.now() at creation
+  turnsHeld: number | null;      // null iff playerID is null; else non-negative integer
+}
+```
+
+- **Market contracts**: `type: "market"`, start with `playerID: null`, claimable by any player.
+- **Private contracts**: `type: "private"`, always have a `playerID` (generated for/assigned to that player).
+- **Value when fulfilled** is *derived*, not stored: `moneyValue(contract)` = shortest distance (in route segments) from destination to the nearest commodity-producing city × $3,000; `railroadTieValue(contract)` = 1–4, from a destination-region × commodity-region matrix. Both in `src/Contract.ts`.
+
+---
+
+## 2. `ctx` — game context
+
+**Source of truth:** `src/stores/gameStore.ts` (`GameContext`).
+
+```ts
+export interface GameContext {
+  phase: string;          // one of PhaseName (see moveValidation.ts): 'waiting_for_players' | 'setup' | 'play' | 'scoring'
+  currentPlayer: string;  // player ID whose turn it is
+  numPlayers: number;
+  playOrder: string[];    // turn order, as player IDs
+  playOrderPos: number;   // index into playOrder for currentPlayer
+  turn: number;           // global turn counter
+  round: number;          // round counter (increments when playOrder wraps, in the `play` phase)
+}
+```
+
+- **Phase** gates which moves are allowed (`MOVES_BY_PHASE` in `src/stores/moveValidation.ts`) and drives phase transitions (`checkPhaseTransition` in `src/stores/phaseManager.ts`, config in `src/stores/phaseConfig.ts`). See [PHASES_AGENT_GUIDE.md](PHASES_AGENT_GUIDE.md) for the full system.
+- **Moves** (`src/stores/gameActions.js`) mutate `G` and sometimes `ctx` (e.g. `endTurn` advances `currentPlayer`/`playOrderPos`/`turn`, and `round` at the end-of-round hook in `phaseConfig.ts`).
+
+### Other store state (not part of `G`/`ctx` but co-located)
+
+`GameStoreState` (same file) also holds `turnStartSnapshot` (`{ G, ctx } | null`, for undo) and `hasMovedThisTurn: boolean`. These are session/UI-adjacent, not persisted game state.
+
+### Persisted shape
+
+`src/utils/stateSerialization.js` persists exactly `{ G, ctx }` (validated by `isValidSerializedState`, which requires `ctx.phase`, `currentPlayer`, `numPlayers`, `playOrder`, `playOrderPos`, `turn`). Don't add a second persistence path — extend this validator/shape if you add fields to `G` or `ctx`.
+
+---
+
+## 3. Hard-coded map data (`src/data/`)
+
+Cities, routes, and commodities are static reference data — not game state. All three are exported as `Map<string, T>` from `src/data/index.ts` (re-exporting `cities.ts`, `routes.ts`, `commodities.ts`). Keys are stable strings used throughout `G` (e.g. `Contract.destinationKey`, `PlayerProps.activeCities`, `Contract.commodity`).
+
+### Cities — `src/data/cities.ts` (56 entries)
+
+```ts
+export interface City {
+  id: string;              // 3-letter short code, used in Contract.id
+  state: string;
+  country: string;
+  region: string;           // one of RegionCode: NW | NC | NE | SW | SC | SE
+  label: string | null;     // alternate/full display name, e.g. "Portland, Maine"; null if none
+  latitude: number;
+  longitude: number;
+  large: boolean;           // affects city "value" (contract-generation weighting)
+  westCoast: boolean;
+  nearWestCoast: boolean;   // biases contract-generation direction
+  nearEastCoast: boolean;   // biases contract-generation direction
+  commodities: string[];    // commodity keys produced here (into `commodities` map)
+  routes: string[];         // route keys incident on this city (into `routes` map)
+}
+
+export const cities = new Map<string, City>([...]);
+```
+
+- **Map key** = city display name (e.g. `"Atlanta"`, `"Portland ME"` — note some cities are disambiguated with a state suffix in the key itself, distinct from `label`).
+- Graph traversal (shortest path, "cities connected to", contract generation) uses `city.routes` — see `src/utils/graph.js`.
+
+Example:
+
+```ts
+[ "Atlanta", { id: "atl", state: "GA", country: "US", region: "SE", label: null,
+  latitude: 33.7491, longitude: -84.3902, large: true,
+  westCoast: false, nearWestCoast: false, nearEastCoast: true,
+  commodities: ["coal", "cotton", "textiles"],
+  routes: ["Atlanta-Birmingham", "Atlanta-Cincinnati", "Atlanta-Raleigh", "Atlanta-Savannah", "Atlanta-Tallahassee"] } ]
+```
+
+### Routes — `src/data/routes.ts` (105 entries)
+
+```ts
+export interface Route {
+  length: number;         // segment count, 1–5; each segment = $3,000 of contract value
+  mountainous: boolean;   // blocks some contract-generation paths (see routeTestFn usage in Contract.ts)
+  cities: string[];       // exactly two city keys (into `cities` map)
+}
+
+export const routes = new Map<string, Route>([...]);
+```
+
+- **Map key** = `"CityA-CityB"` (city keys joined by a hyphen).
+- **Consistency requirement:** every route should also be listed in `cities` for *both* endpoint cities' `routes` array, or it becomes unreachable via `citiesConnectedTo`/graph traversal. When adding a route, update both city records.
+
+Example:
+
+```ts
+[ "Atlanta-Birmingham", { length: 1, mountainous: false, cities: ["Atlanta", "Birmingham"] } ],
+[ "Bismarck-Butte",     { length: 5, mountainous: true,  cities: ["Bismarck", "Butte"] } ],
+```
+
+### Commodities — `src/data/commodities.ts` (25 entries)
+
+```ts
+export interface Commodity {
+  regions: string[];   // RegionCode values where this commodity can be sourced (used for regional-office contract generation)
+  cities: string[];     // producing city keys (denormalized — keep in sync with each City.commodities)
+}
+
+export const commodities = new Map<string, Commodity>([...]);
+```
+
+- **Map key** = commodity name, also the value stored in `Contract.commodity`.
+- Full key list: `aluminum, bauxite, cattle, coal, copper, cotton, fish, fruit, grain, imports, iron ore, lead, machinery, nickel, oil, pork, precious metals, rice, sheep, steel, textiles, tobacco, tourists, wine, wood`.
+- **Consistency requirement:** `commodities.get(x).cities` should match the set of cities whose `commodities` array contains `x`. When adding/removing a commodity from a city, update both sides.
+- UI icons are mapped separately in `src/shared/assets/icons.js` (`commodityIcons`, keyed by the same commodity strings).
+
+---
+
+## 4. Extending this data
+
+- **New city/route/commodity:** add to the relevant `Map` in `src/data/`, and update the cross-references described above (city ↔ route, city ↔ commodity). No other file needs to enumerate them — `graph.js` and `Contract.ts` traverse the maps directly.
+- **New field on `G` or `ctx`:** add it to `GameState`/`GameContext` in `src/stores/gameStore.ts`, update `getInitialState`, and extend the persisted shape in `src/utils/stateSerialization.js` (and its validator) if it needs to survive save/reload.
+- **New per-player field:** add to `PlayerProps` in `src/stores/gameStore.ts`; initialize it in `getInitialState`'s `players` construction.
+- **New contract field:** add to `Contract` in `src/Contract.ts`; update `newContract()` to set a default, and `stateSerialization.js` if persistence needs validation beyond the generic `unknown[]` for `contracts`.
+- Do not add a second source of truth for any of the above — see [AGENTS.md](../AGENTS.md) anti-patterns.

--- a/src/Contract.test.ts
+++ b/src/Contract.test.ts
@@ -9,19 +9,37 @@ import {
 } from './Contract';
 import { cities, commodities } from './data';
 
+type PlayerProps = {
+  name: string;
+  activeCities: string[];
+  hubCity: string | null;
+  regionalOffice: string | null;
+};
+
 /** Minimal game state shape for contract tests (matches Contract's expected shape). */
 function makeGameState(
   activeCities: string[],
-  currentPlayer: string = '0'
+  options: {
+    currentPlayer?: string;
+    contracts?: Contract[];
+    regionalOffice?: string | null;
+    hubCity?: string | null;
+  } = {}
 ): {
-  G: { contracts: Contract[]; players: [string, { name: string; activeCities: string[]; hubCity: string | null; regionalOffice: string | null }][] };
+  G: { contracts: Contract[]; players: [string, PlayerProps][] };
   ctx: { currentPlayer: string };
 } {
+  const {
+    currentPlayer = '0',
+    contracts = [],
+    regionalOffice = null,
+    hubCity = null,
+  } = options;
   return {
     G: {
-      contracts: [],
+      contracts,
       players: [
-        ['0', { name: 'P0', activeCities, hubCity: null, regionalOffice: null }],
+        ['0', { name: 'P0', activeCities, hubCity, regionalOffice }],
         ['1', { name: 'P1', activeCities: ['Chicago', 'Detroit'], hubCity: null, regionalOffice: null }],
       ],
     },
@@ -29,6 +47,26 @@ function makeGameState(
       currentPlayer,
     },
   };
+}
+
+/** Build fulfilled contracts attributed to a player (any commodity/destination is fine for counting). */
+function makeFulfilledContracts(playerID: string, count: number): Contract[] {
+  const samples: Array<{ destinationKey: string; commodity: string }> = [
+    { destinationKey: 'Chicago', commodity: 'coal' },
+    { destinationKey: 'Boston', commodity: 'imports' },
+    { destinationKey: 'Atlanta', commodity: 'machinery' },
+    { destinationKey: 'Denver', commodity: 'grain' },
+  ];
+  return Array.from({ length: count }, (_, i) => {
+    const sample = samples[i % samples.length];
+    const contract = newContract(sample.destinationKey, sample.commodity, {
+      type: i % 2 === 0 ? 'private' : 'market',
+      fulfilled: true,
+      playerID,
+    });
+    if (!contract) throw new Error('Failed to create fulfilled contract fixture');
+    return contract;
+  });
 }
 
 describe('generatePrivateContractSpec', () => {
@@ -56,11 +94,59 @@ describe('generatePrivateContractSpec', () => {
   test('returns undefined when players array is empty', () => {
     const G = {
       contracts: [] as Contract[],
-      players: [] as [string, { name: string; activeCities: string[]; hubCity: string | null; regionalOffice: string | null }][],
+      players: [] as [string, PlayerProps][],
     };
     const ctx = { currentPlayer: '0' };
     const spec = generatePrivateContractSpec(G, ctx);
     expect(spec).toBeUndefined();
+  });
+
+  test('with fewer than 3 fulfilled contracts, can still generate specs worth less than $6000', () => {
+    const { G, ctx } = makeGameState(['New York', 'Philadelphia'], {
+      contracts: makeFulfilledContracts('0', 2),
+    });
+    let sawLowValue = false;
+    for (let i = 0; i < 80; i++) {
+      const spec = generatePrivateContractSpec(G, ctx);
+      if (spec && moneyValue(spec) < 6000) {
+        sawLowValue = true;
+        break;
+      }
+    }
+    expect(sawLowValue).toBe(true);
+  });
+
+  test('with 3+ fulfilled contracts, prefers specs worth at least $6000 when enough commodities qualify', () => {
+    // Use a distant commodityRegion so many candidates are ≥ 2 segments from NE destinations
+    // (ensuring the filtered pool has ≥ 2 commodities and the floor applies).
+    const { G, ctx } = makeGameState(['New York', 'Philadelphia', 'Pittsburgh'], {
+      contracts: makeFulfilledContracts('0', 3),
+    });
+    for (let i = 0; i < 40; i++) {
+      const spec = generatePrivateContractSpec(G, ctx, 'SW');
+      if (!spec) continue;
+      expect(moneyValue(spec)).toBeGreaterThanOrEqual(6000);
+    }
+  });
+
+  test('with 3+ fulfilled contracts, falls back to unfiltered list when fewer than 2 high-value commodities', () => {
+    // Seattle's nearby commodity set is small; many destinations leave 0–1 commodities at distance ≥ 2.
+    const { G, ctx } = makeGameState(['Seattle'], {
+      contracts: makeFulfilledContracts('0', 3),
+    });
+    let gotSpec = false;
+    let sawLowValue = false;
+    for (let i = 0; i < 50; i++) {
+      const spec = generatePrivateContractSpec(G, ctx);
+      if (!spec) continue;
+      gotSpec = true;
+      if (moneyValue(spec) < 6000) {
+        sawLowValue = true;
+      }
+    }
+    expect(gotSpec).toBe(true);
+    // Fallback must allow sub-$6k contracts rather than failing generation.
+    expect(sawLowValue).toBe(true);
   });
 });
 
@@ -110,6 +196,21 @@ describe('generatePrivateContractOffers', () => {
       expect(destCity!.commodities.includes(offer.commodity)).toBe(false);
     });
   });
+
+  test('with 3+ fulfilled contracts, regional-office offer prefers $6000+ when enough commodities qualify', () => {
+    // SW regional office from NE active cities: first offer uses SW commodities, which are
+    // far from NE destinations, so the $6k floor applies to that offer.
+    const { G, ctx } = makeGameState(['New York', 'Philadelphia', 'Pittsburgh'], {
+      contracts: makeFulfilledContracts('0', 3),
+      regionalOffice: 'SW',
+    });
+    for (let i = 0; i < 30; i++) {
+      const offers = generatePrivateContractOffers(G, ctx);
+      expect(offers.length).toBeGreaterThanOrEqual(3);
+      // First offer is the regional-office offer
+      expect(moneyValue(offers[0])).toBeGreaterThanOrEqual(6000);
+    }
+  });
 });
 
 describe('generateMarketContract', () => {
@@ -119,7 +220,7 @@ describe('generateMarketContract', () => {
       players: [
         ['0', { name: 'P0', activeCities: ['New York', 'Philadelphia', 'Pittsburgh'], hubCity: null, regionalOffice: null }],
         ['1', { name: 'P1', activeCities: ['Raleigh', 'Norfolk'], hubCity: null, regionalOffice: null }],
-      ] as [string, { name: string; activeCities: string[]; hubCity: string | null; regionalOffice: string | null }][],
+      ] as [string, PlayerProps][],
     };
 
     for (let i = 0; i < 20; i++) {

--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -134,7 +134,7 @@ export function generateStartingContract(
  *
  * @param G - Game state object
  * @param ctx - Game context
- * @param commodityRegion - Optional region code (NW, NC, NE, SW, SC, SE). If provided, candidate commodities are those supplied in that region instead of within one hop of active cities.
+ * @param commodityRegion - Optional region code of a regional office. If provided, commodity will be from that region.
  * @returns A spec with commodity and destinationKey, or undefined
  */
 export function generatePrivateContractSpec(
@@ -203,8 +203,22 @@ export function generatePrivateContractSpec(
   const destCity = cities.get(contractCity);
   if (destCity) destCity.commodities.forEach((c) => availableCommodities.delete(c));
 
+  // Once a player has fulfilled 3+ contracts, prefer commodities worth at least $6k,
+  // but fall back to the unfiltered list if that would leave fewer than 2 choices.
+  let commodityPool = availableCommodities;
+  if (countFulfilledContracts(G, ctx.currentPlayer) >= 3) {
+    const highValueCommodities = filterCommoditiesByMinDistance(
+      availableCommodities,
+      contractCity,
+      2
+    );
+    if (highValueCommodities.size >= 2) {
+      commodityPool = highValueCommodities;
+    }
+  }
+
   // Pick a commodity for the contract
-  const contractCommodity = randomSetItem(availableCommodities);
+  const contractCommodity = randomSetItem(commodityPool);
   if (!contractCommodity) return undefined;
 
   return { commodity: contractCommodity, destinationKey: contractCity };
@@ -312,16 +326,7 @@ export function generateMarketContract(G: GameState): Contract | undefined {
 
   // Filter out commodities that are too close to the destination (distance < 2).
   // This ensures all market contracts are worth at least $6k (2 segments × $3k)
-  const validCommodities = new Set<string>();
-  possibleCommodities.forEach((commodity) => {
-    const distance = shortestDistance(
-      contractCity,
-      (c: string) => (cities.get(c)?.commodities.includes(commodity) ?? false)
-    );
-    if (distance !== undefined && distance >= 2) {
-      validCommodities.add(commodity);
-    }
-  });
+  const validCommodities = filterCommoditiesByMinDistance(possibleCommodities, contractCity, 2);
 
   // TODO: Write test to ensure this case never happens (low priority, seems very unlikely by inspection)
   if (validCommodities.size === 0) {
@@ -334,6 +339,35 @@ export function generateMarketContract(G: GameState): Contract | undefined {
   if (!contractCommodity) return undefined;
 
   return newContract(contractCity, contractCommodity, { type: "market" });
+}
+
+/**
+ * Returns the subset of commodities whose nearest producing city is at least
+ * minDistance segments from destinationKey.
+ */
+function filterCommoditiesByMinDistance(
+  candidateCommodities: Set<string>,
+  destinationKey: string,
+  minDistance: number
+): Set<string> {
+  const valid = new Set<string>();
+  candidateCommodities.forEach((commodity) => {
+    const distance = shortestDistance(
+      destinationKey,
+      (c: string) => cities.get(c)?.commodities.includes(commodity) ?? false
+    );
+    if (distance !== undefined && distance >= minDistance) {
+      valid.add(commodity);
+    }
+  });
+  return valid;
+}
+
+/**
+ * Counts fulfilled contracts (private or market) held by the given player.
+ */
+function countFulfilledContracts(G: GameState, playerID: string): number {
+  return G.contracts.filter((c) => c.playerID === playerID && c.fulfilled).length;
 }
 
 /**

--- a/src/independentRailroads.ts
+++ b/src/independentRailroads.ts
@@ -178,6 +178,8 @@ export function growIndependentRailroads(
   const smallestMappedOccupancy = Math.min(...growthProbabilities.keys());
   const largestMappedOccupancy = Math.max(...growthProbabilities.keys());
 
+  const LARGEST_RR_ROUTE_COUNT = 7;
+
   // Collect keys of all active cities and what's adjacent to them
   const activeCities = new Set<string>();
   for (const [, player] of G.players) {
@@ -230,7 +232,16 @@ export function growIndependentRailroads(
   const numberOfRoutesToAdd = newRouteCount - startingRouteCount;
   const addedRoutes = new Set<string>();
 
-  const indieEntries = Object.entries(G.independentRailroads);
+  // Candidate RR list, filtered to only include RRs that are at or below the cap
+  const indieEntries = Object.entries(G.independentRailroads).filter(
+    ([, rr]) => {
+      // 85% of the time, the cap is one below the max, otherwise at the max
+      const cap = Math.random() < 0.85 ? LARGEST_RR_ROUTE_COUNT - 1 : LARGEST_RR_ROUTE_COUNT;
+      return rr.routes.length <= cap;
+ 
+    }
+  );
+  if (indieEntries.length === 0) return undefined;
   const maxAttempts = 100;
 
   for (


### PR DESCRIPTION
## Summary
- Apply a $6,000 minimum value floor to private contract generation once a player has fulfilled 3+ contracts (private or market), with fallback when fewer than 2 qualifying commodities exist.
- Extract shared `filterCommoditiesByMinDistance` helper used by both market and private contract generation.
- Cap independent railroad growth at 7 routes (85% of the time at 6) to prevent runaway expansion.
- Add `docs/GAME_DATA_SCHEMA.md` as a reference for G, ctx, and map data shapes.

## Test plan
- [ ] Run `npm test` — new tests cover the $6k floor, fallback behavior, and regional-office offers
- [ ] Fulfill 3 contracts as a player and verify subsequent private offers tend toward $6k+ values
- [ ] Verify private offers still generate when only 0–1 commodities meet the distance threshold (Seattle scenario)
- [ ] Play through several rounds and confirm independent railroads stop growing past the route cap